### PR TITLE
fix: include ServerPipeName in composition test

### DIFF
--- a/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
+++ b/src/LanguageServer/Microsoft.CodeAnalysis.LanguageServer.UnitTests/Utilities/LanguageServerTestComposition.cs
@@ -36,7 +36,8 @@ internal sealed class LanguageServerTestComposition
             DevKitDependencyPath: devKitDependencyPath,
             RazorSourceGenerator: null,
             RazorDesignTimePath: null,
-            ExtensionLogDirectory: string.Empty);
+            ExtensionLogDirectory: string.Empty,
+            ServerPipeName: null);
         var extensionManager = ExtensionAssemblyManager.Create(serverConfiguration, loggerFactory);
         assemblyLoader = new CustomExportAssemblyLoader(extensionManager, loggerFactory);
         return ExportProviderBuilder.CreateExportProviderAsync(extensionManager, assemblyLoader, devKitDependencyPath, loggerFactory);


### PR DESCRIPTION
Fix broken composition tests missing `ServerPipeName` parameter.